### PR TITLE
Avoid using `*= require` in Sass

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,18 +1,2 @@
-/*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS and SCSS file within this directory, lib/assets/stylesheets, vendor/assets/stylesheets,
- * or any plugin's vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any styles
- * defined in the other CSS/SCSS files in this directory. It is generally better to create a new
- * file per style scope.
- *
- *= require_tree .
- *= require_self
- */
-
 @import "bootstrap-sprockets";
 @import "bootstrap";

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -1,2 +1,3 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
+@import "records";


### PR DESCRIPTION
The `bootstrap-sass` docs recommend against using `*= require` in Sass:

> Then, remove all the `*= require_self` and `*= require_tree .` statements from the sass file. Instead, use `@import` to import Sass files.
> 
> Do not use `*= require` in Sass or your other stylesheets will not be [able to access](https://github.com/twbs/bootstrap-sass/issues/79#issuecomment-4428595) the Bootstrap mixins or variables.
